### PR TITLE
Reworked Attributes tab navigation

### DIFF
--- a/css/elements/_navigation.css
+++ b/css/elements/_navigation.css
@@ -24,6 +24,10 @@
     border-radius: var(--corner-length-large);
     position: relative;
 
+    cursor: pointer;
+    border-width: 0;
+    border-bottom-width: var(--clickable-border-width);
+
     &:hover,
     &:focus {
         border-color: var(--tab-button-interact-border-color);
@@ -44,7 +48,7 @@
     }
 }
 
-.shortcut {
+#attributesDisplay.tabButton {
     cursor: pointer;
     border-width: 0;
     border-bottom-width: var(--clickable-border-width);

--- a/css/elements/_navigation.css
+++ b/css/elements/_navigation.css
@@ -24,10 +24,6 @@
     border-radius: var(--corner-length-large);
     position: relative;
 
-    cursor: pointer;
-    border-width: 0;
-    border-bottom-width: var(--clickable-border-width);
-
     &:hover,
     &:focus {
         border-color: var(--tab-button-interact-border-color);
@@ -48,6 +44,7 @@
     }
 }
 
+.shortcut,
 #attributesDisplay.tabButton {
     cursor: pointer;
     border-width: 0;

--- a/css/global/_main.css
+++ b/css/global/_main.css
@@ -137,25 +137,12 @@ a#gameTitle {
     border-left: 3px solid var(--active-color);
 }
 
-.bar-animation {
-    position: absolute;
-    inset: 0;
-    background-image: repeating-linear-gradient(
-        45deg,
-        transparent,
-        transparent 4px,
-        var(--active-color) 4px,
-        var(--active-color) 8px
-    );
-    pointer-events: none;
-}
-
-.bar-animation.horizontal {
+#content.horizontal {
     background-repeat: repeat-x;
     background-size: 100% 0;
 }
 
-.bar-animation.vertical {
+#content.vertical {
     background-repeat: repeat-y;
     background-size: 0 100%;
 }

--- a/css/global/_main.css
+++ b/css/global/_main.css
@@ -137,6 +137,30 @@ a#gameTitle {
     border-left: 3px solid var(--active-color);
 }
 
+.bar-animation {
+    position: absolute;
+    inset: 0;
+    background-image: repeating-linear-gradient(
+        45deg,
+        transparent,
+        transparent 4px,
+        var(--active-color) 4px,
+        var(--active-color) 8px
+    );
+    pointer-events: none;
+}
+
+.bar-animation.horizontal {
+    background-repeat: repeat-x;
+    background-size: 100% 0;
+}
+
+.bar-animation.vertical {
+    background-repeat: repeat-y;
+    background-size: 0 100%;
+}
+
+
 .panel {
     background-color: var(--panel-bg-color);
 }

--- a/css/global/_main.css
+++ b/css/global/_main.css
@@ -134,19 +134,21 @@ a#gameTitle {
     background-image: repeating-linear-gradient(45deg, transparent, transparent 4px, var(--active-color) 4px, var(--active-color) 8px);
     background-repeat: repeat-y;
     background-size: 0 100%;
-    border-left: 3px solid var(--active-color);
-}
 
-#content.horizontal {
-    background-repeat: repeat-x;
-    background-size: 100% 0;
-}
+    &.horizontal {
+        background-repeat: repeat-x;
+        background-size: 100% 0;
+        border-left: 'none'; 
+        border-top: 3px solid var(--active-color);
+    }
 
-#content.vertical {
-    background-repeat: repeat-y;
-    background-size: 0 100%;
+    &.vertical {
+        background-repeat: repeat-y;
+        background-size: 0 100%;
+        border-top: 'none';
+        border-left: 3px solid var(--active-color);
+    }
 }
-
 
 .panel {
     background-color: var(--panel-bg-color);

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
         </div>
 
         <div id="attributesDisplay"
-             class="shortcut tabButton panel px-3 py-1 d-flex justify-content-start gap-4 overflow-x-auto"
+             class="tabButton panel px-3 py-1 d-flex justify-content-start gap-4 overflow-x-auto"
              onclick="setTab('attributes');">
             <div class="primary-stat" data-attribute="population"
                  data-bs-placement="bottom" data-bs-html="true">
@@ -271,7 +271,6 @@
         <hr id="connector" class="d-none d-lg-block" />
 
         <div id="content" class="panel flex-fill position-relative mh-100 overflow-auto">
-            <div class="bar-animation"></div>
             <template id="level1Template">
                 <div class="level1">
                     <div class="level1-header d-flex justify-content-start py-2 px-2 mb-0">

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
         </div>
 
         <div id="attributesDisplay"
-             class="shortcut panel px-3 py-1 d-flex justify-content-start gap-4 overflow-x-auto"
+             class="shortcut tabButton panel px-3 py-1 d-flex justify-content-start gap-4 overflow-x-auto"
              onclick="setTab('attributes');">
             <div class="primary-stat" data-attribute="population"
                  data-bs-placement="bottom" data-bs-html="true">
@@ -248,13 +248,6 @@
                         <span class="pointOfInterest text-truncate">Point of Interest</span>
                     </div>
                 </button>
-                <div id="attributesTabButtonRequirements" class="requirements-container m-2">
-                    <span class="help-text">Required: Defeated Astrogoblins level 12 / 25</span>
-                </div>
-                <button id="attributesTabButton" class="tabButton panel p-3" onClick="setTab('attributes');">
-                    <!--suppress HtmlUnknownTag -->
-                    <h3>Attributes</h3>
-                </button>
                 <button id="galacticSecretsTabButton" class="tabButton panel p-3" onClick="setTab('galacticSecrets');">
                     <!--suppress HtmlUnknownTag -->
                     <h3>Galactic Secrets</h3>
@@ -278,6 +271,7 @@
         <hr id="connector" class="d-none d-lg-block" />
 
         <div id="content" class="panel flex-fill position-relative mh-100 overflow-auto">
+            <div class="bar-animation"></div>
             <template id="level1Template">
                 <div class="level1">
                     <div class="level1-header d-flex justify-content-start py-2 px-2 mb-0">

--- a/js/game-config/requirements.js
+++ b/js/game-config/requirements.js
@@ -399,20 +399,6 @@ const htmlElementRequirements = {
             elementsToShowRequirements: [Dom.get().byId('locationTabButtonRequirements')],
             prerequirements: [moduleOperationRequirements.PocketLaboratory],
         }),
-    attributesTabButton: new HtmlElementWithRequirement(
-        {
-            elementsWithRequirements: [Dom.get().byId('attributesTabButton')],
-            requirements: [new AttributeRequirement('playthrough', [{
-                attribute: attributes.research,
-                requirement: 10,
-            }])],
-            elementsToShowRequirements: [Dom.get().byId('attributesTabButtonRequirements')],
-            // Same as for LocationTabButton
-            prerequirements: [new OperationLevelRequirement('playthrough', [{
-                operation: moduleOperations.PocketLaboratory,
-                requirement: 10,
-            }])],
-        }),
     battleMultiEngageHelp: new HtmlElementWithRequirement(
         {
             elementsWithRequirements: [

--- a/js/main.js
+++ b/js/main.js
@@ -90,13 +90,11 @@ function setTab(selectedTab) {
     tabButtons[selectedTab].classList.add('active');
 
     const content = Dom.get().byId('content');
-    const animBar = content.querySelector('.bar-animation');
 
-    if(isVerticalBarAnimation) {
-        content.style.borderTop = 'none';
-        content.style.borderLeft = '3px solid var(--active-color)';
-        animBar.className = 'bar-animation vertical';
-        animBar.animate(
+    if (isVerticalBarAnimation) {
+        content.classList.add('vertical');
+        content.classList.remove('horizontal');
+        content.animate(
             [
                 {offset: 0.0, backgroundSize: '0 100%'},
                 {offset: 0.1, backgroundSize: '24px 100%'},
@@ -110,12 +108,10 @@ function setTab(selectedTab) {
             },
         );
       
-    }
-    else {
-        content.style.borderLeft = 'none';
-        content.style.borderTop = '3px solid var(--active-color)';
-        animBar.className = 'bar-animation horizontal';
-        animBar.animate(
+    } else {
+        content.classList.add('horizontal');
+        content.classList.remove('vertical');
+        content.animate(
             [
                 {offset: 0.0, backgroundSize: '100% 0'},
                 {offset: 0.1, backgroundSize: '100% 24px'},
@@ -159,8 +155,6 @@ function updateConnector() {
     const activeTabButton = Dom.get().bySelector('.tabButton.active');
     const connectorElement = Dom.get().byId('connector');
     const contentElement = Dom.get().byId('content');
-
-    if (!activeTabButton || !connectorElement || !contentElement) return;
 
     const connectorThickness = 3;
 

--- a/js/main.js
+++ b/js/main.js
@@ -1814,9 +1814,6 @@ function updateStationOverview() {
 
     const galacticSecretCost = calculateGalacticSecretCost();
     formatValue(Dom.get().byId('galacticSecretCostDisplay'), galacticSecretCost, {forceInteger: true, keepNumber: true});
-
-    // Only shot the attributes display as a shortcut link if the attributes tab is actually available
-    Dom.get().byId('attributesDisplay').classList.toggle('shortcut', !tabButtons['attributes'].classList.contains('hidden'));
 }
 
 const htmlElementRequirementsHtmlCache = {};


### PR DESCRIPTION
- Don't hide it behind research (removed Requirements for attributesTabButton in js\game-config\requirements.js)
- make attributes instantly clickable to show attributes tab (changed in js\main.js by removing attributesTabButton from tabButtons and adding attributesDisplay to tabButtons)
- when clicking attributes tab again, close attributes tab (added logic in js\main.js in function setTab(selectedTab){..})
- remove attributes tab from the side bar (in index.html: added tabButton to class and removed attributesTabButtonRequirements + attributesTabButton)

Did some additional changes in css\global\_main.css for visual appearance and js\main.js in function setTab(selectedTab){..} for horizontal Animation (AttributesTab) and function updateConnector(){..} for the vertical connection line between active element and content